### PR TITLE
Relocate whole adventure package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ shadowJar {
         include(dependency("net.kyori:adventure-text-serializer-legacy"))
     }
 
-    relocate "net.kyori.adventure.text.minimessage", "net.zithium.library.shaded.minimessage"
-    relocate "net.kyori.adventure.text.serializer.legacy", "net.zithium.library.shaded.legacyserializer"
+    
+    relocate "net.kyori.adventure.text", "net.zithium.library.shaded.adventure"
     archiveFileName="ZithiumLibrary-${project.version}.jar"
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'net.zithium.library'
-version = '2.1.4'
+version = '2.1.5'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Fixes issues where users are using a paper version below 1.21.4 by shading and relocating the whole adventure package.